### PR TITLE
Adds icon for cart nav bar

### DIFF
--- a/src/components/utilities/NavBar.vue
+++ b/src/components/utilities/NavBar.vue
@@ -33,20 +33,29 @@
             Dashboard
           </router-link>
         </div>
-        <div class="flex justify-end">
+        <div class="flex justify-end align-middle block">
           <router-link
             v-on:click.native='selectPage(4)'
             :class="{ 'selected' : currentPage == 4 }"
-            class="link-gray px-4" 
+            class="link-gray px-4 relative flex" 
             to="/cart"
           >
-            Cart
+            <svg class="flex-1 w-6 h-8 fill-current" viewbox="0 0 24 24">
+              <path 
+                d="M17,18C15.89,18 15,18.89 15,20A2,2 0 0,0 17,22A2,2 0 0,0 19,20C19,18.89 18.1,18 17,18M1,2V4H3L6.6,11.59L5.24,14.04C5.09,14.32 5,14.65 5,15A2,2 0 0,0 7,17H19V15H7.42A0.25,0.25 0 0,1 7.17,14.75C7.17,14.7 7.18,14.66 7.2,14.63L8.1,13H15.55C16.3,13 16.96,12.58 17.3,11.97L20.88,5.5C20.95,5.34 21,5.17 21,5A1,1 0 0,0 20,4H5.21L4.27,2M7,18C5.89,18 5,18.89 5,20A2,2 0 0,0 7,22A2,2 0 0,0 9,20C9,18.89 8.1,18 7,18Z"/>
+            </svg>
+            <span 
+              class="absolute right-0 top-0 rounded-full bg-red-400 w-4 h-4 top right p-0 m-0 text-white font-mono text-sm leading-tight text-center"
+              v-show="checkCart()"
+            >
+              {{ countCart() }}
+            </span>
           </router-link>
           <router-link
             v-on:click.native='selectPage(5)'
             :class="{ 'selected' : currentPage == 5 }"
             class="link-gray px-4" 
-            to="/login" 
+            to="/login"
             v-if="!signedIn"
           >
             Login
@@ -98,10 +107,16 @@ export default {
     },
     selectPage (selectedPage) {
       this.currentPage = selectedPage
+    },
+    checkCart () {
+      return Object.keys(this.getCart).length !== 0
+    },
+    countCart () {
+      return Object.keys(this.getCart).length
     }
   },
   computed: {
-    ...mapGetters(['signedIn'])
+    ...mapGetters(['signedIn', 'getCart'])
   }
 }
 </script>


### PR DESCRIPTION
## Description
This is a short PR that just adds an icon for the cart in the nav bar.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
The cart also has a span that will show up with the number of items that are in the cart. The reloading of the page isn't happening to trigger the cart count to show up so right now you have to navigate away from the page to get the icon to show up. Will try to fix later.
## Test Results
```
```